### PR TITLE
#157279739 fix invite button to show for email found only and start button on the page of the player that created the game

### DIFF
--- a/public/js/controllers/game.js
+++ b/public/js/controllers/game.js
@@ -28,7 +28,6 @@ angular.module('mean.system') //eslint-disable-line
       $scope.getUserInfo = (user, searchForm) => {
         if (searchForm.$dirty) {
           $scope.resetForm();
-          console.log(searchForm);
           $http({
             method: 'POST',
             url: '/api/search/users',
@@ -248,7 +247,6 @@ angular.module('mean.system') //eslint-disable-line
       if ($location.search().game && !(/^\d+$/).test($location.search().game)) {
         console.log('joining custom game');
         game.joinGame('joinGame', $location.search().game);
-        console.log(game);
       } else if ($location.search().custom) {
         game.joinGame('joinGame', null, true);
       } else {

--- a/public/views/app.html
+++ b/public/views/app.html
@@ -57,7 +57,7 @@
           <h6>{{game.message}}</h6>
         </div>
         <div class="button-div">
-          <span><button class= "user-button" ng-click="sendGameInvite()">Invite</button></span>
+          <span><button class= "user-button" ng-click="sendGameInvite()" ng-if="userInfo.user.email">Invite</button></span>
         </div>
       </div>
     </div>

--- a/public/views/question.html
+++ b/public/views/question.html
@@ -22,7 +22,7 @@
       </div>
 
       <div id="start-game-container" ng-click="game.startGame(game.players.length)" ng-show="(game.playerIndex === 0 || game.joinOverride) && game.players.length >= 1">
-        <div id='start-game-button'>
+        <div id='start-game-button' ng-show="game.playerIndex===0">
           Start Game</br>with 3 players
         </div>
       </div>


### PR DESCRIPTION
#### What does this PR do?
Ensures that the invite button and the start game button works as expected

#### Description of Task to be completed?
- Players whose email only are found should have an invite button on the modal when it pops up.
- The start button should only show for the user who created the game.

#### How should this be manually tested?
Clone the repo and cd into it. Run *npm start* and view the app in chrome, signup and test the features
#### Any background context you want to provide?
- The invite button was showing on the modal even when an error message pops up
- The start button was showing on the game interface of all the players that joined even when they did not create the game
#### What are the relevant pivotal tracker stories?
157279739
#### Screenshots (if appropriate)
None
#### Questions:
None